### PR TITLE
Improve module and code documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/ryanfowler/secrecy.svg)](https://pkg.go.dev/github.com/ryanfowler/secrecy)
 
-`secrecy` is a Go module that enables wrapping sensitive values to prevent
-leaking them through logging, formatting, or other encoding mechanisms.
+`secrecy` is a Go module that enables wrapping sensitive values so that they are
+never shown when the value is printed, logged, or encoded. Any formatting
+interface (`Stringer`, `json.Marshaler`, etc.) will return a constant
+redacted string rather than the underlying value.
 
-This module is inspired by the Rust [`secrecy`](https://docs.rs/secrecy/latest/secrecy/) crate.
+The project is inspired by the Rust
+[`secrecy`](https://docs.rs/secrecy/latest/secrecy/) crate and exposes a
+similar API in Go.
 
 ## Installation
 
@@ -15,8 +19,8 @@ go get github.com/ryanfowler/secrecy@latest
 
 ## Usage
 
-Import the package and wrap sensitive values. In order to access the underlying
-secret, you must use the `Expose()` method.
+Import the package and wrap sensitive values using `secrecy.New`. In order to
+access the underlying secret, you must use the `Expose()` method.
 
 ```go
 import "github.com/ryanfowler/secrecy"
@@ -42,6 +46,44 @@ fmt.Printf("Equal = %t\n", login.Password.Expose() == "secretpassword")
 
 In order to have the underlying secret "zeroed" when the Secret gets garbage
 collected, create the Secret with the `secrecy.NewZeroizing` method.
+
+## Customising the redaction string
+
+The string shown when a secret is formatted defaults to `"[REDACTED]"`. It can
+be changed globally before any `Secret` values are created using
+`secrecy.SetRedactedString`.
+
+```go
+func init() {
+    secrecy.SetRedactedString("***")
+}
+```
+
+All formatting and encoding operations will now emit the custom string.
+
+## Zeroizing secrets
+
+A secret can have it's contents zeroed by calling the `Zero()` method.
+
+```go
+s := secrecy.New([]byte("secretpassword"))
+defer s.Zero()
+
+useSecret(s.Expose())
+```
+
+Alternatively, the `secrecy.NewZeroizing` function returns a pointer to a
+`Secret` that will automatically zero its value once the object becomes
+unreachable and is garbage collected.
+
+```go
+s := secrecy.NewZeroizing([]byte("secretpassword"))
+
+useToken(s.Expose())
+```
+
+After `Zero()` has been invoked, `Expose()` will return the zero value for the
+wrapped type.
 
 ## License
 

--- a/secrecy.go
+++ b/secrecy.go
@@ -1,3 +1,6 @@
+// Package secrecy provides helpers for handling sensitive values. When wrapped
+// in a Secret, the original value will never be printed or encoded unless it is
+// explicitly exposed with the Expose method.
 package secrecy
 
 import (
@@ -17,10 +20,9 @@ func init() {
 	SetRedactedString("[REDACTED]")
 }
 
-// SetRedactedString sets the global value used as the string when a secret is
-// formatted or encoded. This method must be called before any usage of Secret.
-//
-// By default, it is set to "[REDACTED]".
+// SetRedactedString sets the global value used when a secret is formatted or
+// encoded. It should be called during program initialization, before any
+// Secrets are created. By default the string is "[REDACTED]".
 func SetRedactedString(s string) {
 	redacted = s
 	redactedGo = `Secret{` + redacted + `}`
@@ -36,22 +38,26 @@ type Secret[T any] struct {
 }
 
 // New returns a new Secret that wraps the provided value.
+//
+//	password := secrecy.New("p@ssword")
+//	fmt.Println(password) // prints [REDACTED]
 func New[T any](value T) Secret[T] {
 	return Secret[T]{value: value}
 }
 
-// NewZeroizing returns a new Secret that wraps the provided value, and will
-// "zero" the value when the Secret gets garbage collected. Please see the
-// documentation for the Zeroize function for how values are zeroed. The
-// provided value should not be accessed or modified outside of the scope of the
-// returned Secret.
+// NewZeroizing returns a pointer to a Secret that wraps the provided value and
+// automatically zeroes it when the Secret is garbage collected. The value
+// should not be accessed or modified outside of the returned Secret.
+//
+//	token := secrecy.NewZeroizing([]byte("key"))
 func NewZeroizing[T any](value T) *Secret[T] {
 	s := &Secret[T]{value: value}
 	runtime.AddCleanup(s, func(v T) { Zeroize(v) }, value)
 	return s
 }
 
-// Expose returns the underlying secret value.
+// Expose returns the underlying secret value. This is the only way to
+// retrieve the wrapped data.
 func (s Secret[T]) Expose() T {
 	return s.value
 }
@@ -96,16 +102,15 @@ func (s Secret[T]) MarshalTOML() ([]byte, error) {
 	return redactedJSON, nil
 }
 
-// Zero runs the Zeroize function on the underlying secret value. Calling the
-// Expose method afterwards will always return the zero value for type T.
+// Zero runs the Zeroize function on the underlying secret value. After calling
+// Zero, Expose will return the zero value for type T.
 func (s *Secret[T]) Zero() {
 	Zeroize(&s.value)
 }
 
-// Zeroize deep "zeros" the provided value, if mutable. It traverses slices,
-// maps, and struct fields as necessary to deep zero all child elements. Please
-// note that although structs are fully zeroed, private struct fields cannot
-// be deep zeroed.
+// Zeroize recursively zeroes the provided value in place when possible. It
+// traverses slices, maps and structs, clearing every reachable element. Private
+// struct fields are skipped as they cannot be modified via reflection.
 func Zeroize(value any) {
 	zeroize(reflect.ValueOf(value), 0)
 }


### PR DESCRIPTION
## Summary
- expand README with details on customizing the redaction string and using zeroizing secrets
- add introductory package comment
- clarify comments on exported functions and provide usage examples

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68451f3b33648325a80354fce90eed6e