### PR TITLE
Update Go version to v1.24.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: ["main"]
 
 env:
-  GO_VERSION: "1.24.4"
+  GO_VERSION: "1.24.5"
 
 jobs:
   build:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ryanfowler/secrecy
 
-go 1.24.4
+go 1.24.5


### PR DESCRIPTION
## Summary
- Updates `go.mod` to use Go v1.24.5
- Updates CI workflow to use Go v1.24.5

## Test plan
- [x] CI workflow will validate the change
- [x] All existing tests should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)