### PR TITLE
Fix Zeroize for unaddressable arrays

### DIFF
--- a/secrecy.go
+++ b/secrecy.go
@@ -139,14 +139,19 @@ func zeroize(v reflect.Value, n int) {
 		}
 	case reflect.Array, reflect.Slice:
 		// Fast path for when value is a []byte.
-		if v.Type().Elem().Kind() == reflect.Uint8 {
+		if v.Kind() == reflect.Slice && v.Type().Elem().Kind() == reflect.Uint8 {
 			b := v.Bytes()
 			for i := range b {
 				b[i] = 0
 			}
 		} else {
 			for i := range v.Len() {
-				zeroize(v.Index(i).Addr(), n+1)
+				elem := v.Index(i)
+				if elem.CanAddr() {
+					zeroize(elem.Addr(), n+1)
+				} else {
+					zeroize(elem, n+1)
+				}
 			}
 		}
 	case reflect.Map:

--- a/secrecy_test.go
+++ b/secrecy_test.go
@@ -243,6 +243,26 @@ func TestZeroize(t *testing.T) {
 		}
 	})
 
+	t.Run("unaddressable array", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Zeroize panicked: %v", r)
+			}
+		}()
+
+		Zeroize([3]int{1, 2, 3})
+	})
+
+	t.Run("unaddressable byte array", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Zeroize panicked: %v", r)
+			}
+		}()
+
+		Zeroize([3]byte{1, 2, 3})
+	})
+
 	t.Run("map", func(t *testing.T) {
 		value := map[int]int{1: 100, 2: 200, 3: 300}
 		Zeroize(value)
@@ -270,6 +290,14 @@ func TestZeroize(t *testing.T) {
 				t.Errorf("expected s2 backing array to be zeroed, got: %v", s2)
 				break
 			}
+		}
+	})
+
+	t.Run("map with byte array values", func(t *testing.T) {
+		value := map[string][3]byte{"a": {1, 2, 3}}
+		Zeroize(value)
+		if len(value) != 0 {
+			t.Errorf("expected empty map, got: %v", value)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Avoid panics when Zeroize walks unaddressable array values
- Restrict the byte-slice fast path to slices, not arrays
- Add regression tests for array literals and map values with byte arrays

## Testing
- Unit tests added for unaddressable arrays and byte-array map values
- `go test ./...` passed locally