### PR TITLE
Fix map struct zeroization

### DIFF
--- a/secrecy.go
+++ b/secrecy.go
@@ -164,8 +164,13 @@ func zeroize(v reflect.Value, n int) {
 		t := v.Type()
 		for i := range t.NumField() {
 			field := v.Field(i)
-			if field.CanAddr() && v.Type().Field(i).IsExported() {
+			if !t.Field(i).IsExported() {
+				continue
+			}
+			if field.CanAddr() {
 				zeroize(field.Addr(), n+1)
+			} else {
+				zeroize(field, n+1)
 			}
 		}
 	}

--- a/secrecy_test.go
+++ b/secrecy_test.go
@@ -293,6 +293,25 @@ func TestZeroize(t *testing.T) {
 		}
 	})
 
+	t.Run("map with struct slice values", func(t *testing.T) {
+		type holder struct {
+			B []byte
+		}
+
+		b := []byte("secret")
+		value := map[string]holder{"k": {B: b}}
+		Zeroize(value)
+		if len(value) != 0 {
+			t.Errorf("expected empty map, got: %v", value)
+		}
+		for _, c := range b {
+			if c != 0 {
+				t.Errorf("expected aliased backing array to be zeroed, got: %q", b)
+				break
+			}
+		}
+	})
+
 	t.Run("map with byte array values", func(t *testing.T) {
 		value := map[string][3]byte{"a": {1, 2, 3}}
 		Zeroize(value)


### PR DESCRIPTION
## Summary
- Traverse exported struct fields even when the struct value is not addressable, so reachable mutable data gets zeroed before map entries are cleared.
- Add a regression test covering a map value struct that aliases an external `[]byte` backing array.

## Testing
- `go test ./...`